### PR TITLE
Use directory variable instead of always "."

### DIFF
--- a/pt.el
+++ b/pt.el
@@ -79,7 +79,7 @@
                         pt-arguments
                         args
                         '("-e" "--nogroup" "--nocolor" "--")
-                        (list (shell-quote-argument regexp) ".")) " ")
+                        (list (shell-quote-argument regexp) directory)) " ")
      'pt-search-mode)))
 
 ;;;###autoload


### PR DESCRIPTION
I was wondering why it would always use "." as directory, no matter folder I passed it (in non-interactive mode).

This does not seems to break the interactive usage so, it should be a *win-win* :wink:.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>