### PR TITLE
Revert "Use directory variable instead of always ".""

### DIFF
--- a/pt.el
+++ b/pt.el
@@ -91,7 +91,7 @@
                         pt-arguments
                         args
                         '("-e" "--nogroup" "--nocolor" "--")
-                        (list (shell-quote-argument regexp) directory)) " ")
+                        (list (shell-quote-argument regexp) ".")) " ")
      'pt-search-mode)))
 
 ;;;###autoload


### PR DESCRIPTION
This reverts commit ff5306d4d5eabab7621ab22566f28139f7d577a7.

This changes was actually not needed. The explanation is there https://github.com/bling/pt.el/commit/ff5306d4d5eabab7621ab22566f28139f7d577a7#commitcomment-12741757 (from @binmarin). If the folder *passed* to `default-directory` doesn't end with a trailing slash (`/`) then it does not work — and the change makes it not work anymore with tramp.

@bling I'm so sorry to make you revert that one :sweat: (and to have you make merge it in the first place :sob:). misread a bit the documentation of `default-directory`. That was my piece of code that I should have fixed, not this one :sweat_smile:.