### PR TITLE
Make sure directory path has correct format

### DIFF
--- a/pt.el
+++ b/pt.el
@@ -111,7 +111,7 @@ This function is called from `compilation-filter-hook'."
   "Run a pt search with REGEXP rooted at DIRECTORY."
   (interactive (list (read-from-minibuffer "Pt search for: " (thing-at-point 'symbol))
                      (read-directory-name "Directory: ")))
-  (let ((default-directory directory))
+  (let ((default-directory (file-name-as-directory directory)))
     (compilation-start
      (mapconcat 'identity
                 (append (list pt-executable)


### PR DESCRIPTION
default-directory value should be processed with file-name-as-directory. Otherwise hyperlinks to search matches might not work.

If you call pt-regexp with a path which does not end with '/' (on Linux) the search will be performed in parent directory and hyperlinks will not work. This does not happen often because completion usually adds the slash.